### PR TITLE
ci(docker): use release target to build Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY . .
 
 RUN go mod download -x
-RUN make build_linux
+RUN make release
 
 FROM alpine:latest
 


### PR DESCRIPTION
## Description

This PR is using `release` target to build the Dockerfile.
