### PR TITLE
chore: update golangci.yml lint and fix lint error

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - errorlint
     - exhaustive
     - copyloopvar
+    - forbidigo
     - gci
     - gocheckcompilerdirectives
     - gocognit
@@ -41,6 +42,7 @@ linters:
     - loggercheck
     - maintidx
     - makezero
+    - mirror
     - misspell
     - musttag
     - nakedret
@@ -48,6 +50,7 @@ linters:
     - nilerr
     - nilnil
     - nlreturn
+    - noctx
     - nolintlint
     - nosprintfhostport
     - prealloc
@@ -60,6 +63,7 @@ linters:
     - stylecheck
     - tagalign
     - tagliatelle
+    - usetesting
     - testableexamples
     - thelper
     - tparallel
@@ -68,9 +72,9 @@ linters:
     - usestdlibvars
     - wastedassign
     - whitespace
-    # - wrapcheck
     - zerologlint
     - varnamelen
+    - ireturn
 
 linters-settings:
   gosimple:
@@ -80,11 +84,8 @@ linters-settings:
     enable-all-rules: true
     rules:
       - name: "exported"
-        # TODO: Enable me
-        # all exported function should have comment.
         disabled: true
 
-      # TODO: Enable me
       - name: package-comments
         disabled: true
 
@@ -130,6 +131,9 @@ linters-settings:
       - name: redefines-builtin-id
         disabled: true
 
+      - name: "var-naming"
+        disabled: true
+
       - name: unhandled-error
         arguments:
           - "fmt.Printf"
@@ -148,8 +152,13 @@ linters-settings:
       - G115
 
   stylecheck:
-    # TODO: enable ST1000 (at least one file in a package should have a package comment)
-    checks: ["all", "-ST1000"]
+    # ST1000: at least one file in a package should have a package comment
+    # ST1003: should not use underscores in package names
+    checks: ["all", "-ST1000", "-ST1003"]
+
+  staticcheck:
+    # SA1019: xyz is deprecated
+    checks: ["all", "-SA1019"]
 
   govet:
     enable-all: true
@@ -175,6 +184,16 @@ linters-settings:
         json: snake
         yaml: snake
 
+  gocritic:
+    disabled-checks:
+      - ifElseChain
+      - unnamedResult
+      - importShadow
+    enabled-tags:
+      - diagnostic
+      - style
+      - performance
+
   nestif:
     # Minimal complexity of if statements to report.
     # Default: 5
@@ -193,6 +212,8 @@ linters-settings:
       - il
       - r # reader
       - w # writer
+      - db # database
+      - tx # transaction
 
     ignore-decls:
       - wg sync.WaitGroup
@@ -200,6 +221,14 @@ linters-settings:
       - td *testData
       - ma multiaddr.Multiaddr
       - db *leveldb.DB
+
+  ireturn:
+    allow:
+      - anon
+      - error
+      - empty
+      - stdlib
+      - "github.com/ezex-io/proxier/internal/server.Server"
 
 issues:
   exclude-use-default: false
@@ -209,9 +238,11 @@ issues:
         - maintidx
         - nestif
         - gocognit
+        - forbidigo
 
   exclude:
-    - "shadow: declaration of \"err\" shadows"
-    - "builtinShadow: shadowing of predeclared identifier: min"
-    - "builtinShadow: shadowing of predeclared identifier: max"
-    - "builtinShadow: shadowing of predeclared identifier: len"
+    - 'shadow: declaration of "err" shadows'
+    - 'builtinShadow: shadowing of predeclared identifier: min'
+    - 'builtinShadow: shadowing of predeclared identifier: max'
+    - 'builtinShadow: shadowing of predeclared identifier: len'
+    

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -131,10 +131,6 @@ linters-settings:
       - name: redefines-builtin-id
         disabled: true
 
-      - name: "var-naming"
-        arguments:
-          - ["package"] # exclude package names from checking
-
       - name: unhandled-error
         arguments:
           - "fmt.Printf"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,7 +132,8 @@ linters-settings:
         disabled: true
 
       - name: "var-naming"
-        disabled: true
+        arguments:
+          - ["package"] # exclude package names from checking
 
       - name: unhandled-error
         arguments:

--- a/cmd/proxier/main.go
+++ b/cmd/proxier/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -24,7 +23,7 @@ func main() {
 	flag.Parse()
 
 	if *ver {
-		fmt.Println("Proxier v" + version.Version.String())
+		log.Info("Proxier version", "version", version.Version.String())
 		os.Exit(0)
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,10 +11,10 @@ import (
 func createTempConfig(t *testing.T, content string) string {
 	t.Helper()
 
-	tmpFile, err := os.CreateTemp("", "config_test_*.yaml")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "config_test_*.yaml")
 	require.NoError(t, err, "Failed to create temp file")
 
-	_, err = tmpFile.Write([]byte(content))
+	_, err = tmpFile.WriteString(content)
 	require.NoError(t, err, "Failed to write to temp file")
 
 	err = tmpFile.Close()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-func HTTPHandler(endpoint string, destination string) (string, http.HandlerFunc, error) {
+func HTTPHandler(endpoint, destination string) (string, http.HandlerFunc, error) {
 	targetURL, err := url.Parse(destination)
 	if err != nil {
 		return "", nil, fmt.Errorf("invalid destination URL %s: %w", destination, err)
@@ -34,7 +34,7 @@ func HTTPHandler(endpoint string, destination string) (string, http.HandlerFunc,
 	return endpoint, proxy.ServeHTTP, nil
 }
 
-func FastHTTPHandler(endpoint string, destination string) (string, fasthttp.RequestHandler, error) {
+func FastHTTPHandler(endpoint, destination string) (string, fasthttp.RequestHandler, error) {
 	targetURL, err := url.Parse(destination)
 	if err != nil {
 		return "", nil, fmt.Errorf("invalid destination URL %s: %w", destination, err)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -45,7 +45,12 @@ func TestProxyHandler(t *testing.T) {
 	proxyServer := httptest.NewServer(handler)
 	defer proxyServer.Close()
 
-	resp, err := http.Get(fmt.Sprintf("%s/mockpath", proxyServer.URL))
+	url := fmt.Sprintf("%s/mockpath", proxyServer.URL)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+	require.NoError(t, err, "Creating request should not fail")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	require.NoError(t, err, "Proxy request should not fail")
 	defer func() {
 		_ = resp.Body.Close()
@@ -64,7 +69,12 @@ func TestProxyHandler_Unreachable(t *testing.T) {
 	proxyServer := httptest.NewServer(handler)
 	defer proxyServer.Close()
 
-	resp, err := http.Get(fmt.Sprintf("%s/test", proxyServer.URL))
+	url := fmt.Sprintf("%s/test", proxyServer.URL)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+	require.NoError(t, err, "Creating request should not fail")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	defer func() {
 		_ = resp.Body.Close()
 	}()

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -43,7 +43,12 @@ func TestRootEndpoint(t *testing.T) {
 	testServer := httptest.NewServer(sv.httpServer.Handler)
 	defer testServer.Close()
 
-	resp, err := http.Get(fmt.Sprintf("%s/", testServer.URL))
+	url := fmt.Sprintf("%s/", testServer.URL)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+	require.NoError(t, err)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer func() {
 		_ = resp.Body.Close()
@@ -62,7 +67,12 @@ func TestLivezEndpoint(t *testing.T) {
 	testServer := httptest.NewServer(sv.httpServer.Handler)
 	defer testServer.Close()
 
-	resp, err := http.Get(fmt.Sprintf("%s/livez", testServer.URL))
+	url := fmt.Sprintf("%s/livez", testServer.URL)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+	require.NoError(t, err)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer func() {
 		_ = resp.Body.Close()
@@ -83,7 +93,12 @@ func TestProxyRoutes(t *testing.T) {
 
 	for _, rule := range proxyRules {
 		t.Run(fmt.Sprintf("Proxy Route %s", rule.Endpoint), func(t *testing.T) {
-			resp, err := http.Get(fmt.Sprintf("%s%s", testServer.URL, rule.Endpoint))
+			url := fmt.Sprintf("%s%s", testServer.URL, rule.Endpoint)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+			require.NoError(t, err)
+
+			client := &http.Client{}
+			resp, err := client.Do(req)
 			require.NoError(t, err)
 			defer func() {
 				_ = resp.Body.Close()
@@ -106,7 +121,7 @@ func TestServerStartStop(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	srv.Stop(ctx)
 }


### PR DESCRIPTION
## Description

- update golangci to latest, new rules: newFastHTTP return interface, so we need to exclude it
- fix lint errors

## Related Issue

Fixes # (issue)
